### PR TITLE
Fixes for shellcheck

### DIFF
--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -19,7 +19,7 @@ cleanup() {
         log "cleaning up..."
     fi
 
-    docker ps -a | grep -q $containerid && docker rm -f $containerid
+    docker ps -a | grep -q "$containerid" && docker rm -f "$containerid"
 }
 
 trap "cleanup SIGINT" SIGINT
@@ -29,7 +29,7 @@ trap "cleanup" EXIT
 
 log  "Building in a container..."
 
-randstr=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 8 | head -n 1)
+randstr=$(tr -dc 'a-z0-9' < /dev/urandom | fold -w 8 | head -n 1)
 containerid=krita-appimage-build-$randstr
 imageid="krita-appimage-build"
 
@@ -42,7 +42,7 @@ log "Creating container $containerid"
 mkdir -p workspace/ out/
 set -xe
 docker run -it \
-    --name $containerid \
+    --name "$containerid" \
     -v "$(readlink -f out/):/out" \
     -e VERSION -e BRANCH -e ARCH -e REPO_URL -e SUDO_UID -e SUDO_GID \
     $imageid \


### PR DESCRIPTION
Minor fixes for `shellcheck` check.

FWIW, running before and after these changes, my out and workspace folders are empty.

No clear errors in the console either.